### PR TITLE
Added reconnect on error after configurable timeout.

### DIFF
--- a/dashboard-server.html
+++ b/dashboard-server.html
@@ -30,14 +30,14 @@ var values = [
         category: 'ur robot',
         color: '#C0DEED',
         defaults: {
-            name: {value:""},
-            host: {value:"localhost",required:true},
-            port: {value:29999,required:true,validate:RED.validators.number()},
-            command: {value:""},
-            argument: {value:""},
-            usemsgtopic: {value: false}
-            
-        },
+    name: {value:""},
+    host: {value:"localhost", required:true},
+    port: {value:29999, required:true, validate:RED.validators.number()},
+    command: {value:""},
+    argument: {value:""},
+    usemsgtopic: {value: false},
+    timeout: {value: 5}
+				},
         inputs:1,
         outputs:1,
         icon: "ur.png",
@@ -45,28 +45,46 @@ var values = [
             return this.name||"dashboard-server";
         },
         oneditprepare: function(){
-            for (var i = 0; i < values.length; i++) {
-                var value = values[i].value;
-                $('#node-input-command').append($("<option></option>").attr("value", value).text(value));
-            }                
-            // Make sure the selected value is also selected in the <select> tag
-            $('#node-input-command').val(this.command);
+    for (var i = 0; i < values.length; i++) {
+        var value = values[i].value;
+        $('#node-input-command').append($("<option></option>").attr("value", value).text(value));
+    }
+    
+    // Make sure the selected value is also selected in the <select> tag
+    $('#node-input-command').val(this.command);
 
-            $('#node-input-command').on('change', ()=>{
-                var val = $('#node-input-command').val();
-                for (let i = 0; i < values.length; i++) {
-                    const element = values[i];
-                    if(element.value === val){
-                        if(element.argument === false){
-                            $('#node-argument').hide();
-                        }else{
-                            $('#node-argument').show();
-                            $('#node-input-argument').attr("placeholder", element.placeholder);
-                        }
-                    }                    
+    // Handle command changes
+    $('#node-input-command').on('change', ()=>{
+        var val = $('#node-input-command').val();
+        for (let i = 0; i < values.length; i++) {
+            const element = values[i];
+            if(element.value === val){
+                if(element.argument === false){
+                    $('#node-argument').hide();
+                }else{
+                    $('#node-argument').show();
+                    $('#node-input-argument').attr("placeholder", element.placeholder);
                 }
-            });
+            }
         }
+    });
+
+    // Set initial timeout value if already configured
+    $('#node-input-timeout').val(this.timeout || 5); // Default to 5 if not set
+
+    // Timeout value control
+    $('#node-timeout-up').on('click', function() {
+        var currentValue = parseInt($('#node-input-timeout').val(), 10);
+        $('#node-input-timeout').val(currentValue + 1);
+    });
+
+    $('#node-timeout-down').on('click', function() {
+        var currentValue = parseInt($('#node-input-timeout').val(), 10);
+        if (currentValue > 1) {
+            $('#node-input-timeout').val(currentValue - 1);
+        }
+    });
+}
     });
 </script>
 
@@ -92,6 +110,14 @@ var values = [
             <label for="node-input-argument">argument</label>
             <input type="text" id="node-input-argument">
     </div>
+    <br>
+    <div class="form-row">
+    <label for="node-input-timeout">Timeout (seconds)</label>
+    <input type="number" id="node-input-timeout" min="1" max="3600" value="5" step="1" />
+    <button type="button" id="node-timeout-up">?</button>
+    <button type="button" id="node-timeout-down">?</button>
+</div>
+
     <br>
     <div class="form-row" >
             <label for="node-input-usemsgtopic">use msg.topic</label>

--- a/dashboard-server.js
+++ b/dashboard-server.js
@@ -1,47 +1,107 @@
 var net = require('net');
 
-
 module.exports = function(RED) {
     function DashboardServer(config) {
-        RED.nodes.createNode(this,config);
+        RED.nodes.createNode(this, config);
         var node = this;
-        // tcp client
-        var client = new net.Socket();
-        client.connect(parseInt(config.port), config.host, function() {
-            node.log('connected to host: ' + config.host + ':' + config.port);
-            node.status({fill:"green",shape:"dot",text:"connected"});
-        });        
-        client.on('data', function(data) {
-            data = data.toString().replace('\n','');
-            var result = {
-                "payload"   : data,
-                "topic"     : node.context()['last-ur-command'] ||'',
-                "timestamp" : new Date().valueOf()
+        
+        var client = null;
+        var retrying = false; // Ensures retries happen only once during the timeout period
+        var reconnectTimeout = parseInt(config.timeout, 10) * 1000 || 5000; // Default to 5 seconds
+
+        // Function to create and connect the client
+        function createClient() {
+            if (client) {
+                client.end();  // Gracefully close the previous connection
             }
-            node.send(result);
-        });
-        client.on('close', function(reason) {
-            node.log('disconnected from host: ' + config.host + ':' + config.port);
-            node.status({fill:"red",shape:"ring",text:"disconnected"});
-        });
-        client.on('error', function(err) {
-            node.error('error at tcp connection', err);
-        });
+
+            client = new net.Socket();
+            node.status({ fill: "yellow", shape: "ring", text: "connecting" });
+            client.connect(parseInt(config.port), config.host, function() {
+                // Create and send a message to the debug window
+                var debugMsg = { payload: node.name + '\nconnected to host: ' + config.host + ':' + config.port };
+                node.send(debugMsg);  // This sends the message to the debug window
+                node.status({ fill: "green", shape: "dot", text: "connected" });
+            });
+
+            client.on('data', function(data) {
+                data = data.toString().replace('\n', '');
+                var result = {
+                    "payload": data,
+                    "topic": node.context()['last-ur-command'] || '',
+                    "timestamp": new Date().valueOf()
+                };
+                node.send(result); // This sends the data to the output
+            });
+
+            client.on('close', function(reason) {
+                // Create and send a message to the debug window
+                var debugMsg = { payload: node.name + '\ndisconnected from host: ' + config.host + ':' + config.port };
+                node.send(debugMsg);  // This sends the message to the debug window
+                node.status({ fill: "red", shape: "ring", text: "disconnected" });
+
+                // Only attempt to reconnect if not already retrying
+                if (!retrying) {
+                    retrying = true;
+                    // Create and send a message to the debug window
+                    var retryMsg = { payload: node.name + '\nAttempting to reconnect in ' + reconnectTimeout / 1000 + ' seconds...' };
+                    node.send(retryMsg);  // This sends the message to the debug window
+                    
+                    // Delay reconnection with setTimeout
+                    setTimeout(function() {
+                        retrying = false; // Reset retrying flag
+                        createClient(); // Try reconnecting after the timeout
+                    }, reconnectTimeout);
+                }
+            });
+
+            client.on('error', function(err) {
+                // Create and send a message to the debug window
+                var errorMsg = { payload: node.name + '\nError at tcp connection: ' + err.message };
+                node.send(errorMsg);  // This sends the message to the debug window
+                node.status({ fill: "red", shape: "ring", text: "error" });
+
+                // Only attempt to reconnect if not already retrying
+                if (!retrying) {
+                    retrying = true;
+                    // Create and send a message to the debug window
+                    var retryMsg = { payload: node.name + '\nAttempting to reconnect in ' + reconnectTimeout / 1000 + ' seconds...' };
+                    node.send(retryMsg);  // This sends the message to the debug window
+                    
+                    // Delay reconnection with setTimeout
+                    setTimeout(function() {
+                        retrying = false; // Reset retrying flag
+                        createClient(); // Try reconnecting after the timeout
+                    }, reconnectTimeout);
+                }
+            });
+        }
+
+        // Initial connection
+        createClient();
+
         node.on('input', function(msg) {
             try {
                 var arg = config.argument || '';
-                var com = config.command  || '';
+                var com = config.command || '';
                 var command = com + ' ' + arg + '\n';
-                if(config.usemsgtopic === true){
+                if (config.usemsgtopic === true) {
                     command = msg.topic + '\n';
                 }
-                client.write(command);
+                if (client && client.writable) {
+                    client.write(command);
+                }
                 this.context()['last-ur-command'] = msg.topic || com + ' ' + arg;
+
+                // Send debug message to the debug window with node name
+                var debugMsg = { payload: node.name + '\nSending command: ' + command };
+                node.send(debugMsg);  // This sends the message to the debug window
             } catch (error) {
-                node.error('error at input ', err);
+                var errorMsg = { payload: node.name + '\nError at input: ' + error.message };
+                node.send(errorMsg);  // This sends the message to the debug window
             }
-            
         });
     }
-    RED.nodes.registerType("dashboard-server",DashboardServer);
-}
+
+    RED.nodes.registerType("dashboard-server", DashboardServer);
+};


### PR DESCRIPTION
When using the dashboard server on a real robot, I found that if the robot was taken out of "automatic mode" in order to alter the program, that the dashboard server would only reconnect after restarting node red. 
This commit has the following...
Added configurable reconnect timeout value to node. Altered code to reconnect after timeout expired.
Added code to send status messages to debug window. Include node name in debug messages.